### PR TITLE
feat: Add secure password remember functionality

### DIFF
--- a/qml/ConfigurationPage.qml
+++ b/qml/ConfigurationPage.qml
@@ -24,6 +24,7 @@ Page {
 
     property bool crashReportEnabled: false
     property string serverUrl: ""
+    property bool rememberPassword: false
 
     function loadConfiguration() {
         python.call('main.get_configuration', [], function(config) {
@@ -35,6 +36,10 @@ Page {
                     configurationPage.serverUrl = config.server_url;
                     serverUrlField.text = config.server_url;
                 }
+
+                if (config.hasOwnProperty('remember_password'))
+                    configurationPage.rememberPassword = config.remember_password;
+
             }
         });
     }
@@ -167,6 +172,24 @@ Page {
                     onToggled: function(checked) {
                         configurationPage.crashReportEnabled = checked;
                         python.call('main.set_crash_logs', [checked], function() {
+                        });
+                    }
+                }
+
+            }
+
+            ConfigurationGroup {
+                width: parent.width
+                title: i18n.tr("Security")
+
+                ToggleOption {
+                    width: parent.width
+                    title: i18n.tr("Remember Password")
+                    subtitle: i18n.tr("Save password securely for faster login")
+                    checked: configurationPage.rememberPassword
+                    onToggled: function(checked) {
+                        configurationPage.rememberPassword = checked;
+                        python.call('main.set_remember_password', [checked], function() {
                         });
                     }
                 }

--- a/qml/LoginPage.qml
+++ b/qml/LoginPage.qml
@@ -44,9 +44,20 @@ Page {
             loginScreenData = result;
             visibleFields = result.fields || [];
             isCheckingLogin = false;
-            if (!result.show)
+            if (!result.show) {
                 navigateToPasswordList();
+            } else {
+                // Load remembered password if it exists
+                loadRememberedPassword();
+            }
+        });
+    }
 
+    function loadRememberedPassword() {
+        python.call('main.get_remembered_password', [], function(result) {
+            if (result && result.enabled && result.password) {
+                password = result.password;
+            }
         });
     }
 

--- a/src/ut_components/memoize.py
+++ b/src/ut_components/memoize.py
@@ -210,3 +210,25 @@ def delete_all_memoized():
     """
     with KV() as kv:
         kv.delete_partial("memoize")
+
+
+def memoize_enabled() -> bool:
+    """
+    Check if memoization is enabled for the application.
+
+    Returns:
+        bool: True if memoization is enabled, False otherwise.
+    """
+    with KV() as kv:
+        return kv.get("memoize.enabled", False) or False
+
+
+def set_memoize(enabled: bool) -> None:
+    """
+    Enable or disable memoization for the application.
+
+    Args:
+        enabled (bool): True to enable memoization, False to disable it.
+    """
+    with KV() as kv:
+        kv.put("memoize.enabled", enabled)


### PR DESCRIPTION
This commit implements a secure password remember feature that allows users to store their Bitwarden master password locally for faster subsequent logins.

## Features

### Security Implementation
- AES-256 encryption using the cryptography library
- PBKDF2-HMAC-SHA256 key derivation with 480,000 iterations
- Unique salt per user based on email address
- Automatic cleanup when feature is disabled
- Silent error handling for decryption failures

### User Interface
- Security settings section with toggle option
- Auto-fill functionality on login screen
- Immediate password removal when disabled
- Seamless integration with existing authentication flow

### Files Modified
- src/main.py: Added password encryption/decryption functions and configuration handling
- src/ut_components/memoize.py: Added memoize_enabled() and set_memoize() functions
- qml/ConfigurationPage.qml: Added Security section with Remember Password toggle
- qml/LoginPage.qml: Implemented auto-fill functionality